### PR TITLE
Update tinyproxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM alpine:3
 COPY tinyproxy.conf /etc/tinyproxy/tinyproxy.conf
-RUN apk update && apk add --no-cache tinyproxy=1.11.1-r2
+RUN apk update && apk add --no-cache tinyproxy=1.11.1-r3
 VOLUME /etc/tinyproxy
 EXPOSE 8888
 CMD ["tinyproxy", "-d"]


### PR DESCRIPTION
### What is the context of this PR?
Updates the tinyproxy version to 1.11.1-r3

### How to review 
- Test building a concourse locally using these instructions https://github.com/ONSdigital/eq-runner-concourse/tree/upgrade-concourse-gke-version-to-1.27
- After cloning this repo do the manual process and see that building the image fails
- Make this change to the Dockerfile and see that it now passes