### PR TITLE
Update tinyproxy version to 1.11.2-r0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM alpine:3
 COPY tinyproxy.conf /etc/tinyproxy/tinyproxy.conf
-RUN apk update && apk add --no-cache tinyproxy=1.11.1-r3
+RUN apk update && apk add --no-cache tinyproxy=1.11.2-r0
 VOLUME /etc/tinyproxy
 EXPOSE 8888
 CMD ["tinyproxy", "-d"]


### PR DESCRIPTION
### What is the context of this PR?
Update to the latest version used by Alpine https://pkgs.alpinelinux.org/package/edge/main/armhf/tinyproxy. Allows us to continue deploying concourse after the update.

### How to review 
Check `eq-runner-concourse` README on how to manually push tinyproxy Docker image to your artifact registry, check if it works as expected now.